### PR TITLE
Find a free port for PyOCD telnet semi-hosting

### DIFF
--- a/src/abstract-server.ts
+++ b/src/abstract-server.ts
@@ -48,8 +48,10 @@ export abstract class AbstractServer extends EventEmitter {
 
             try {
                 this.timer = setTimeout(() => this.onSpawnError(new Error('Timeout waiting for gdb server to start')), TIMEOUT);
+
                 const command = args.gdbServer || 'gdb-server';
-                this.process = spawn(command, args.gdbServerArguments, {
+                const serverArguments = await this.resolveServerArguments(args.gdbServerArguments);
+                this.process = spawn(command, serverArguments, {
                     cwd: dirname(command),
                 });
 
@@ -76,6 +78,10 @@ export abstract class AbstractServer extends EventEmitter {
         if (this.process) {
             this.process.kill('SIGINT');
         }
+    }
+
+    protected async resolveServerArguments(serverArguments?: string[]): Promise<string[]> {
+        return serverArguments || [];
     }
 
     protected onExit(code: number, signal: string) {

--- a/src/pyocd-server.ts
+++ b/src/pyocd-server.ts
@@ -24,13 +24,34 @@
 */
 
 import { AbstractServer } from './abstract-server';
+import { PortScanner } from './port-scanner';
 
 const LAUNCH_REGEX = /GDB server started/;
 const ERROR_REGEX = /:ERROR:gdbserver:/;
 const PERCENT_MULTIPLIER = 100 / 40; // pyOCD outputs 40 markers for progress
 
 export class PyocdServer extends AbstractServer {
+
+    protected portScanner = new PortScanner();
     protected progress = 0;
+
+    protected async resolveServerArguments(serverArguments?: string[]): Promise<string[]> {
+        if (!serverArguments) {
+            serverArguments = [];
+        }
+
+        const telnetPort = await this.portScanner.findFreePort(4444);
+
+        if (!telnetPort) {
+            return serverArguments;
+        }
+
+        return [
+            ...serverArguments,
+            '--telnet-port',
+            telnetPort.toString()
+        ];
+    }
 
     protected onStdout(chunk: string | Buffer) {
         super.onStdout(chunk);


### PR DESCRIPTION
This PR ensures the telnet semi-hosting is undertaken on a free port in cases where the default (4444) was already in use by the system.