### PR TITLE
Add support for selecting a core to debug in PyOCD

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,11 @@
                 "type": "array",
                 "default": []
               },
+              "gdbCore": {
+                "description": "Core number gdb will connect to",
+                "type": "number",
+                "default": 0
+              },
               "gdbServer": {
                 "type": "string",
                 "description": "Path to gdb server",
@@ -137,6 +142,11 @@
                 "description": "Additional arguments to pass to GDB command line",
                 "type": "array",
                 "default": []
+              },
+              "gdbCore": {
+                "description": "Core number gdb will connect to",
+                "type": "number",
+                "default": 0
               },
               "gdbServer": {
                 "type": "string",

--- a/src/abstract-server.ts
+++ b/src/abstract-server.ts
@@ -41,7 +41,11 @@ export abstract class AbstractServer extends EventEmitter {
     protected launchReject?: (error: any) => void;
     protected timer?: NodeJS.Timer;
 
-    public spawn(args: CmsisRequestArguments): Promise<void> {
+    constructor(protected args: CmsisRequestArguments) {
+        super();
+    }
+
+    public spawn(): Promise<void> {
         return new Promise(async (resolve, reject) => {
             this.launchResolve = resolve;
             this.launchReject = reject;
@@ -49,8 +53,8 @@ export abstract class AbstractServer extends EventEmitter {
             try {
                 this.timer = setTimeout(() => this.onSpawnError(new Error('Timeout waiting for gdb server to start')), TIMEOUT);
 
-                const command = args.gdbServer || 'gdb-server';
-                const serverArguments = await this.resolveServerArguments(args.gdbServerArguments);
+                const command = this.args.gdbServer || 'gdb-server';
+                const serverArguments = await this.resolveServerArguments(this.args.gdbServerArguments);
                 this.process = spawn(command, serverArguments, {
                     cwd: dirname(command),
                 });
@@ -78,6 +82,10 @@ export abstract class AbstractServer extends EventEmitter {
         if (this.process) {
             this.process.kill('SIGINT');
         }
+    }
+
+    public resolveGdbPort(port: number): number {
+        return port;
     }
 
     protected async resolveServerArguments(serverArguments?: string[]): Promise<string[]> {

--- a/src/pyocd-server.ts
+++ b/src/pyocd-server.ts
@@ -35,6 +35,16 @@ export class PyocdServer extends AbstractServer {
     protected portScanner = new PortScanner();
     protected progress = 0;
 
+    public resolveGdbPort(port: number): number {
+        if (this.args.gdbCore) {
+            // PyOCD starts each core on a subsequent port
+            // (e.g. core 0 on starting port, core 1 on starting port +1, etc.)
+            port += this.args.gdbCore;
+        }
+
+        return port;
+    }
+
     protected async resolveServerArguments(serverArguments?: string[]): Promise<string[]> {
         if (!serverArguments) {
             serverArguments = [];


### PR DESCRIPTION
Add support to specify `gdbCore` to debug (default: 0).

Implemented support in the PyOCD server by assuming subsequent cores are brought up on sequential ports after the one found and specified.