### PR TITLE
Fixed output buffering in AbstractServer

### DIFF
--- a/src/abstract-server.ts
+++ b/src/abstract-server.ts
@@ -110,23 +110,23 @@ export abstract class AbstractServer extends EventEmitter {
     }
 
     protected onStdout(chunk: string | Buffer) {
-        this.onData(chunk, this.outBuffer, 'stdout');
+        this.onData(chunk, 'stdout');
     }
 
     protected onStderr(chunk: string | Buffer) {
-        this.onData(chunk, this.errBuffer, 'stderr');
+        this.onData(chunk, 'stderr');
     }
 
-    protected onData(chunk: string | Buffer, buffer: string, event: string) {
-        buffer += typeof chunk === 'string' ? chunk
-                : chunk.toString('utf8');
+    protected onData(chunk: string | Buffer, event: 'stdout' | 'stderr') {
+        const bufferName = event === 'stdout' ? 'outBuffer' : 'errBuffer';
+        this[bufferName] += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
 
-        const end = buffer.lastIndexOf('\n');
+        const end = this[bufferName].lastIndexOf('\n');
         if (end !== -1) {
-            const data = buffer.substring(0, end);
+            const data = this[bufferName].substring(0, end);
             this.emit(event, data);
             this.handleData(data);
-            buffer = buffer.substring(end + 1);
+            this[bufferName] = this[bufferName].substring(end + 1);
         }
     }
 


### PR DESCRIPTION
A pass-by-value bug was causing output chunks to be dropped if they did not contain a line feed.

This fix also fixes an intermittent bug with pyOCD integration where the line containing "GDB server started" was dropped. For example, pyOCD might output the following as three separate chunks:

> \r\n
0000935:INFO:gdbserver:GDB server started on port 50000
\r\n

In this case, the previous code would have missed the "server started" line.