### PR TITLE
Reset path and env variables in pyocd process

### DIFF
--- a/src/abstract-server.ts
+++ b/src/abstract-server.ts
@@ -29,6 +29,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
 import { dirname } from 'path';
 import { CmsisRequestArguments } from './cmsis-debug-session';
+import * as nodeProcess from 'process';
 
 const TIMEOUT = 1000 * 10; // 10 seconds
 
@@ -57,6 +58,7 @@ export abstract class AbstractServer extends EventEmitter {
                 const serverArguments = await this.resolveServerArguments(this.args.gdbServerArguments);
                 this.process = spawn(command, serverArguments, {
                     cwd: dirname(command),
+                    env: this.resolveServerEnv()
                 });
 
                 if (!this.process) {
@@ -90,6 +92,10 @@ export abstract class AbstractServer extends EventEmitter {
 
     protected async resolveServerArguments(serverArguments?: string[]): Promise<string[]> {
         return serverArguments || [];
+    }
+
+    protected resolveServerEnv(): NodeJS.ProcessEnv {
+        return nodeProcess.env;
     }
 
     protected onExit(code: number, signal: string) {

--- a/src/pyocd-server.ts
+++ b/src/pyocd-server.ts
@@ -63,6 +63,13 @@ export class PyocdServer extends AbstractServer {
         ];
     }
 
+    protected resolveServerEnv(): NodeJS.ProcessEnv {
+        // Remove env variables and reset PATH
+        return {
+            PATH: ''
+        }
+    }
+
     protected onStdout(chunk: string | Buffer) {
         super.onStdout(chunk);
         const buffer = typeof chunk === 'string' ? chunk : chunk.toString('utf8');


### PR DESCRIPTION
## Changes
- Do not pass `process.env`  to `spawn` of pyOCD tool
- Do not pass System PATH to `spawn` of pyOCD tool

## Reason
- pyOCD fails when there is an incorrect version of libusb on System PATH

Another solution is to allow to pass `gdbServerEnv` similarly to how it is done for `gdbServerArguments`. 