### PR TITLE
Allow to modify env for gdbserver process

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,10 @@
                 "type": "array",
                 "default": []
               },
+              "gdbServerEnv": {
+                "description": "GDB server process env",
+                "type": "object"
+              },
               "objdump": {
                 "type": "string",
                 "description": "Path to objdump executable",
@@ -157,6 +161,10 @@
                 "description": "Additional arguments to pass to GDB server",
                 "type": "array",
                 "default": []
+              },
+              "gdbServerEnv": {
+                "description": "GDB server process env",
+                "type": "object"
               },
               "objdump": {
                 "type": "string",

--- a/src/abstract-server.ts
+++ b/src/abstract-server.ts
@@ -29,6 +29,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { EventEmitter } from 'events';
 import { dirname } from 'path';
 import { CmsisRequestArguments } from './cmsis-debug-session';
+import * as nodeProcess from 'process';
 
 const TIMEOUT = 1000 * 10; // 10 seconds
 
@@ -57,6 +58,7 @@ export abstract class AbstractServer extends EventEmitter {
                 const serverArguments = await this.resolveServerArguments(this.args.gdbServerArguments);
                 this.process = spawn(command, serverArguments, {
                     cwd: dirname(command),
+                    env: this.resolveServerEnv(this.args.gdbServerEnv ? this.args.gdbServerEnv as NodeJS.ProcessEnv : undefined )
                 });
 
                 if (!this.process) {
@@ -90,6 +92,10 @@ export abstract class AbstractServer extends EventEmitter {
 
     protected async resolveServerArguments(serverArguments?: string[]): Promise<string[]> {
         return serverArguments || [];
+    }
+
+    private resolveServerEnv(serverEnv?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+        return serverEnv || nodeProcess.env;
     }
 
     protected onExit(code: number, signal: string) {

--- a/src/cmsis-debug-session.ts
+++ b/src/cmsis-debug-session.ts
@@ -39,6 +39,7 @@ export interface CmsisRequestArguments extends RequestArguments {
     gdbCore?: number;
     gdbServer?: string;
     gdbServerArguments?: string[];
+    gdbServerEnv?: object;
     objdump?: string;
 }
 


### PR DESCRIPTION
## Changes

- add `gdbServerEnv` option. It allows to modify env for gdb server process.