### PR TITLE
Bumped cdt-gdb-adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@types/node": "^12.12.14",
-    "cdt-gdb-adapter": "0.0.15-next.20191220232242.2160d3c.0",
+    "cdt-gdb-adapter": "0.0.16-next.20211006222035.6a625dd.0",
     "vscode-debugadapter": "^1.37.0",
     "vscode-debugprotocol": "^1.37.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,14 +60,14 @@ builtin-modules@^1.1.1:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
-cdt-gdb-adapter@0.0.15-next.20191220232242.2160d3c.0:
-  version "0.0.15-next.20191220232242.2160d3c.0"
-  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-0.0.15-next.20191220232242.2160d3c.0.tgz#b076c27a8d3ffcd07ddf0199996ac0c2461b64f9"
-  integrity sha512-VC0hctpfWHjhQTVxTqJpw0kCeNQxN5VcsEA20GNkGOHBKoc2EDjU7rb4Vb7M4LJJ81JQR9SM02jIjPX/xPNE2Q==
+cdt-gdb-adapter@0.0.16-next.20211006222035.6a625dd.0:
+  version "0.0.16-next.20211006222035.6a625dd.0"
+  resolved "https://registry.yarnpkg.com/cdt-gdb-adapter/-/cdt-gdb-adapter-0.0.16-next.20211006222035.6a625dd.0.tgz#6d96aa2668fca94b91193305d25150faa26b168e"
+  integrity sha512-bdSEUoCyPOEI74zzMALDyiCsZpCJ3R5LONq9xMvQ+G4lXiBgZTdj/78XcJOd4NQpzXhSri59YwKbO83Dmg+LwA==
   dependencies:
     node-addon-api "^1.6.2"
-    vscode-debugadapter "^1.37.1"
-    vscode-debugprotocol "^1.37.0"
+    vscode-debugadapter "^1.48.0"
+    vscode-debugprotocol "^1.48.0"
 
 chalk@^2.0.0, chalk@^2.3.0:
   version "2.4.2"
@@ -200,6 +200,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 node-addon-api@^1.6.2:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
@@ -303,7 +308,7 @@ typescript@^3.7.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
-vscode-debugadapter@^1.37.0, vscode-debugadapter@^1.37.1:
+vscode-debugadapter@^1.37.0:
   version "1.37.1"
   resolved "https://registry.yarnpkg.com/vscode-debugadapter/-/vscode-debugadapter-1.37.1.tgz#7d7076e64e9786fe4fcb0c156e1ed24184a9fb2b"
   integrity sha512-g/xNsUdkrd0DifaoRJ4+wypSMsMbK47fGpetpmIOnOQiDFjtYKvqxsgyUZ4BOj2jKP2Xa40B4YXfUUJpqreWJg==
@@ -311,10 +316,23 @@ vscode-debugadapter@^1.37.0, vscode-debugadapter@^1.37.1:
     mkdirp "^0.5.1"
     vscode-debugprotocol "1.37.0"
 
+vscode-debugadapter@^1.48.0:
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/vscode-debugadapter/-/vscode-debugadapter-1.49.0.tgz#d82777adf31d2b5b651b23fecda9a8797fae98cc"
+  integrity sha512-nhes9zaLanFcHuchytOXGsLTGpU5qkz10mC9gVchiwNuX2Bljmc6+wsNbCyE5dOxu6F0pn3f+LEJQGMU1kcnvQ==
+  dependencies:
+    mkdirp "^1.0.4"
+    vscode-debugprotocol "1.49.0"
+
 vscode-debugprotocol@1.37.0, vscode-debugprotocol@^1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.37.0.tgz#e8c4694a078d18ea1a639553a7a241b35c1e6f6d"
   integrity sha512-ppZLEBbFRVNsK0YpfgFi/x2CDyihx0F+UpdKmgeJcvi05UgSXYdO0n9sDVYwoGvvYQPvlpDQeWuY0nloOC4mPA==
+
+vscode-debugprotocol@1.49.0, vscode-debugprotocol@^1.48.0:
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.49.0.tgz#1ed0b7d9f2806df24ca9f18bb3485de060f85166"
+  integrity sha512-3VkK3BmaqN+BGIq4lavWp9a2IC6VYgkWkkMQm6Sa5ACkhBF6ThJDrkP+/3rFE4G7F8+mM3f4bhhJhhMax2IPfg==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This is necessary to include the new `supportsReadMemoryRequest` capability, introduced [here](https://github.com/eclipse-cdt/cdt-gdb-adapter/commit/6785022e278df29017a905d91103658c17db1236) and the new `supportsWriteMemoryRequest`, introduced [here](https://github.com/eclipse-cdt/cdt-gdb-adapter/commit/6a625dd77eaf9116b54ef9413e520e255ffaa626).

I'm not sure if there is a way to test this before releasing since it's the release that is included in Studio.